### PR TITLE
Enforce php@8.3 dependency

### DIFF
--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -6,11 +6,15 @@ class Terminus < Formula
   license "MIT"
 
   depends_on "composer" => :optional
-
-  uses_from_macos "php"
+  depends_on "php@8.3"
 
   def install
-    bin.install "terminus.phar" => "terminus"
+    libexec.install "terminus.phar"
+
+    (bin/"terminus").write <<~PHP
+      #!#{Formula["php@8.3"].opt_bin}/php
+      <?php require '#{libexec}/terminus.phar';
+    PHP
   end
 
   test do


### PR DESCRIPTION
PHP is no longer bundled with macOS, and homebrew php version is up to 8.4, which `terminus` does not support:

```
PHP 8.4+ is not supported by this version of Terminus.
Check for new versions at https://github.com/pantheon-systems/terminus/releases

Set environment variable TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP to try continuing anyway.
Stopping.
```

Method of php version pinning taken from

https://github.com/Homebrew/homebrew-core/blob/2f65789eeb59b24481c0b1c902a03b95f2bd255f/Formula/p/php-cs-fixer.rb#L15-L22
