### PR TITLE
Update terminus homepage

### DIFF
--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -1,6 +1,6 @@
 class Terminus < Formula
   desc "Terminus is Pantheon's Command-line Interface (CLI)"
-  homepage "https://pantheon.io/terminus"
+  homepage "https://github.com/pantheon-systems/terminus"
   url "https://github.com/pantheon-systems/terminus/releases/download/4.0.1/terminus.phar"
   sha256 "f9cdebe2b74f520ac799f8fa800948eafdaeee14b39bc8f3b272aa4acee0c6f3"
   license "MIT"


### PR DESCRIPTION
Previous homepage url returns a 404. Updated homepage url to the github repo. This will provided brew users the correct homepage when running the command `brew info terminus`