### PR TITLE
[DEVX-5299] Require composer and Homebrew PHP for terminus

### DIFF
--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -5,9 +5,9 @@ class Terminus < Formula
   sha256 "f9cdebe2b74f520ac799f8fa800948eafdaeee14b39bc8f3b272aa4acee0c6f3"
   license "MIT"
 
-  depends_on "composer" => :optional
+  depends_on "composer"
 
-  uses_from_macos "php"
+  depends_on "php"
 
   def install
     bin.install "terminus.phar" => "terminus"


### PR DESCRIPTION
- Make composer a required dependency (remove optional flag)
- Replace uses_from_macos "php" with depends_on "php" to use Homebrew's PHP instead of system PHP
- Ensures consistent PHP environment and proper dependency management
