### PR TITLE
terminus 4.3.2

### DIFF
--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -1,8 +1,8 @@
 class Terminus < Formula
   desc "Terminus is Pantheon's Command-line Interface (CLI)"
   homepage "https://pantheon.io/terminus"
-  url "https://github.com/pantheon-systems/terminus/releases/download/4.3.1/terminus.phar"
-  sha256 "954f5941f549856ab09cccebda6f5028603fef13d660ffbc088a5166145f5bdd"
+  url "https://github.com/pantheon-systems/terminus/releases/download/4.3.2/terminus.phar"
+  sha256 "1eb7be556adba66bfb87d197211bf62671031e7294024c5a35dd8348b84f7aab"
   license "MIT"
 
   depends_on "composer"


### PR DESCRIPTION
Bump Terminus formula to 4.3.2.

Release: https://github.com/pantheon-systems/terminus/releases/tag/4.3.2