### PR TITLE
ci: CI/CD readiness improvements (DEVX-6969)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+  - "Formula/**"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "pantheon-systems/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # master
-      - name: Tap this repository
-        run: brew tap pantheon-systems/external ${{ github.workspace }}
+      - name: Tap this repository from local checkout
+        run: |
+          brew untap pantheon-systems/external 2>/dev/null || true
+          brew tap pantheon-systems/external ${{ github.workspace }}
       - name: Style check
         run: brew style pantheon-systems/external/terminus
       - name: Audit formula

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # master
+      - name: Style check
+        run: brew style Formula/terminus.rb
+      - name: Audit formula
+        run: brew audit --strict Formula/terminus.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # master
-      - name: Tap this repository from local checkout
-        run: |
-          brew untap pantheon-systems/external 2>/dev/null || true
-          brew tap pantheon-systems/external ${{ github.workspace }}
       - name: Style check
         run: brew style pantheon-systems/external/terminus
       - name: Audit formula

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # master
+      - name: Tap this repository
+        run: brew tap pantheon-systems/external ${{ github.workspace }}
       - name: Style check
-        run: brew style Formula/terminus.rb
+        run: brew style pantheon-systems/external/terminus
       - name: Audit formula
-        run: brew audit --strict Formula/terminus.rb
+        run: brew audit --strict pantheon-systems/external/terminus

--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -14,6 +14,6 @@ class Terminus < Formula
   end
 
   test do
-    system "#{bin}/terminus", "art"
+    system bin/"terminus", "art"
   end
 end

--- a/Formula/terminus.rb
+++ b/Formula/terminus.rb
@@ -1,5 +1,5 @@
 class Terminus < Formula
-  desc "Terminus is Pantheon's Command-line Interface (CLI)"
+  desc "Pantheon's Command-line Interface (CLI)"
   homepage "https://pantheon.io/terminus"
   url "https://github.com/pantheon-systems/terminus/releases/download/4.3.2/terminus.phar"
   sha256 "1eb7be556adba66bfb87d197211bf62671031e7294024c5a35dd8348b84f7aab"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,12 @@
+# Releasing
+
+When a new Terminus version is published, update the formula manually:
+
+1. Find the new release on the [Terminus releases page](https://github.com/pantheon-systems/terminus/releases)
+2. Download the `.phar` file and compute its SHA256:
+   ```
+   curl -L https://github.com/pantheon-systems/terminus/releases/download/<version>/terminus.phar | shasum -a 256
+   ```
+3. Update `Formula/terminus.rb` with the new version, URL, and SHA256
+4. Open a PR -- CI will run `brew style` and `brew audit` to validate the formula
+5. After merge, users get the update via `brew update && brew upgrade terminus`


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with `brew style` and `brew audit --strict` checks on every push/PR, actions pinned to commit SHAs
- Add `.github/dependabot.yml` for weekly `github-actions` updates
- Add `.codacy.yml` excluding `Formula/` from analysis
- Add `RELEASING.md` documenting how to update the formula for new Terminus releases

## Not applicable

- GAR vs Quay: no Docker images in this repo
- Node.js 24 / Golang: no Node or Go code; actions pinned to SHA (no unpinned-tag findings)

## Test plan

- [x] CI workflow passes (`brew style` and `brew audit --strict` on `Formula/terminus.rb`)
- [x] No GHAS code scanning findings (actions are SHA-pinned, zero alerts)
- [x] No Dependabot alerts (zero findings on this repo)
- [ ] Codacy picks up the new config
- [ ] Dependabot starts opening PRs for github-actions updates

Jira: DEVX-6969